### PR TITLE
Add expects: fail and ok

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Webstorm
+.idea

--- a/README.md
+++ b/README.md
@@ -634,6 +634,43 @@ I.expectMatchesPattern(actual, pattern); // Passes
 I.expectMatchesPattern(actual, { name: 'Doe' }, 'Object does not match the pattern'); // Fails with custom error message
 ```
 
+### I.expectFail
+
+Forces the current test to fail with an optional custom error message.
+
+```js
+I.expectFail(customErrorMsg = 'expect fail')
+```
+
+* `customErrorMsg`: (Optional) Custom error message to display when the assertion fails.
+
+**Example:**
+
+```js
+I.expectFail('This step should not be reached'); // Fails with custom error message
+```
+
+### I.expectOk
+
+Asserts that a value is truthy.
+
+```js
+I.expectOk(actualValue, customErrorMsg = '')
+```
+
+* `actualValue`: The value to check.
+* `customErrorMsg`: (Optional) Custom error message to display if the assertion fails.
+
+**Example:**
+
+```js
+I.expectOk(true); // Passes
+I.expectOk(1); // Passes
+I.expectOk('text'); // Passes
+I.expectOk(false, 'Expected value to be truthy'); // Fails with custom error message
+```
+
+
 ---
 
 This documentation provides a comprehensive overview of the `ExpectHelper` class and its methods. Each method is designed to perform specific assertions, making it easier to write and maintain tests. The examples provided demonstrate how to use each method effectively.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Enable it inside codecept conf file:
 {
   helpers: {
     Playwright: {...},
-    Expect: {
+    ExpectHelper: {
       require: '@codeceptjs/expect-helper'
     },
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,4 +25,6 @@ declare class ExpectHelper {
     expectDeepIncludeMembers(superset: any[], set: any[], customErrorMsg?: string): void;
     expectDeepEqualExcluding(actualValue: any, expectedValue: any, fieldsToExclude: string | string[], customErrorMsg?: string): void;
     expectMatchesPattern(actualValue: object, expectedPattern: object, customErrorMsg?: string): void;
-  }  
+    expectFail(customErrorMsg?: string): void;
+    expectOk(actualValue: object, customErrorMsg?: string): void;
+  }

--- a/index.js
+++ b/index.js
@@ -410,6 +410,27 @@ class ExpectHelper {
     const errorMessage = customErrorMsg ? `${customErrorMsg}: Expected "${JSON.stringify(actualValue)}" to match the pattern "${JSON.stringify(expectedPattern)}"` : `Expected "${JSON.stringify(actualValue)}" to match the pattern "${JSON.stringify(expectedPattern)}"`;
     return assert(result, errorMessage);
   }
+
+  /**
+   *
+   * @param {*} [customErrorMsg]
+   */
+  expectFail(customErrorMsg = 'expect fail') {
+    // @ts-ignore
+    output.step(`I expect fail`)
+    return expect.fail(customErrorMsg);
+  }
+
+  /**
+   *
+   * @param {*} actualValue
+   * @param {*} [customErrorMsg]
+   */
+  expectOk(actualValue, customErrorMsg = '') {
+    // @ts-ignore
+    output.step(`I expect "${JSON.stringify(actualValue)}" to be ok`)
+    return expect(actualValue, customErrorMsg).to.be.ok;
+  }
 }
 
 export default ExpectHelper

--- a/index_test.js
+++ b/index_test.js
@@ -667,5 +667,48 @@ describe('#expectContain', () => {
     })
   })
 
+  describe('#expectFail', () => {
+    it('should show error', () => {
+      try {
+        I.expectFail('custom failure message')
+      } catch (e) {
+        expect(e.message).to.contain('custom failure message')
+      }
+    })
+
+    it('should show default error', () => {
+      try {
+        I.expectFail()
+      } catch (e) {
+        expect(e.message).to.contain('expect fail')
+      }
+    })
+  })
+
+  describe('#expectOk', () => {
+    it('should not show error', () => {
+      I.expectOk(true)
+      I.expectOk(1)
+      I.expectOk('text')
+      I.expectOk({})
+    })
+
+    it('should show error', () => {
+      try {
+        I.expectOk(false, 'expected value to be ok')
+      } catch (e) {
+        expect(e.message).to.contain('expected value to be ok')
+      }
+    })
+
+    it('should show default chai error', () => {
+      try {
+        I.expectOk(0)
+      } catch (e) {
+        expect(e.message).to.contain('expected +0 to be truthy')
+      }
+    })
+  })
+
 
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeceptjs/expect-helper",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Expect helper for CodeceptJS",
   "type": "module",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary

Adds two new assertion wrappers to `ExpectHelper`:

* `I.expectFail()` to explicitly fail a test with an optional custom message
* `I.expectOk()` to assert that a value is truthy

## Changes

* Implemented `expectFail(customErrorMsg = 'expect fail')`
* Implemented `expectOk(actualValue, customErrorMsg = '')`
* Added TypeScript definitions for both methods
* Added README documentation with examples
* Added unit tests covering:

  * custom failure message
  * default failure message
  * truthy values passing
  * falsy values failing with custom/default Chai messages

## Testing

Added tests in `index_test.js` for both new wrappers.
