### PR TITLE
fix: Change index.d.ts to export default class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare class ExpectHelper {
+export default class ExpectHelper {
     expectEqual(actualValue: any, expectedValue: any, customErrorMsg?: string): void;
     expectNotEqual(actualValue: any, expectedValue: any, customErrorMsg?: string): void;
     expectDeepEqual(actualValue: any, expectedValue: any, customErrorMsg?: string): void;


### PR DESCRIPTION
index.d.ts was missing an `export` statement, trying to import this module in TS code causes compiler error.